### PR TITLE
feat(article): support opus dynamic IDs and fix CV fallback path

### DIFF
--- a/bili_stalker_mcp/models.py
+++ b/bili_stalker_mcp/models.py
@@ -149,7 +149,7 @@ class ArticlesResponse(BaseModel):
 
 
 class ArticleContentResponse(BaseModel):
-    id: int
+    id: str
     title: str | None = None
     markdown_content: str = ""
 

--- a/bili_stalker_mcp/server.py
+++ b/bili_stalker_mcp/server.py
@@ -500,7 +500,7 @@ def create_server() -> FastMCP:
         async def _runner() -> Dict[str, Any]:
             cred = _get_credential_from_context(ctx)
             stripped = article_id.strip()
-            if not stripped.isdigit() or stripped == "0":
+            if not stripped.isdigit() or int(stripped) < 1:
                 raise ToolError(
                     f"article_id must be a positive numeric string, got: {article_id!r}"
                 )

--- a/bili_stalker_mcp/server.py
+++ b/bili_stalker_mcp/server.py
@@ -483,18 +483,28 @@ def create_server() -> FastMCP:
     async def get_article_content(
         ctx: Context,
         article_id: Annotated[
-            int,
+            str,
             Field(
-                ge=1,
-                description="Article CV id.",
+                min_length=1,
+                description=(
+                    "Article id. Accepts a CV id (old format, e.g. 21032785) or "
+                    "an opus dynamic id from a bilibili.com/opus/{id} URL "
+                    "(e.g. 748254891671027745). Passed as a string because opus "
+                    "ids are 64-bit snowflake ids that overflow JS safe integers."
+                ),
             ),
         ],
     ) -> Dict[str, Any]:
-        """Get full article markdown content."""
+        """Get full article markdown content (supports both CV and opus ids)."""
 
         async def _runner() -> Dict[str, Any]:
             cred = _get_credential_from_context(ctx)
-            return await fetch_article_content(article_id=article_id, cred=cred)
+            stripped = article_id.strip()
+            if not stripped.isdigit() or stripped == "0":
+                raise ToolError(
+                    f"article_id must be a positive numeric string, got: {article_id!r}"
+                )
+            return await fetch_article_content(article_id=stripped, cred=cred)
 
         try:
             return await _run_tool("get_article_content", _runner)

--- a/bili_stalker_mcp/services/article_renderer.py
+++ b/bili_stalker_mcp/services/article_renderer.py
@@ -254,26 +254,47 @@ def build_article_fallback_markdown(
     return "\n".join(lines)
 
 
-async def extract_markdown_from_opus_initial_state(
-    article_id: int,
+async def fetch_opus_payload(
+    url: str,
     cred: Credential | None,
-    preferred_title: str | None,
-) -> str | None:
+    preferred_title: str | None = None,
+) -> dict[str, Any] | None:
+    """Fetch an opus-rendered bilibili page and parse title/rid/uid/markdown.
+
+    Works for both new-style ``bilibili.com/opus/{snowflake}`` URLs and legacy
+    ``bilibili.com/read/cv{id}/?jump_opus=1`` redirects — they share the same
+    ``detail.modules.paragraphs`` payload shape.
+    """
     credential = cred if cred is not None else Credential()
-    url = f"https://www.bilibili.com/read/cv{article_id}/?jump_opus=1"
 
     try:
         initial_state, _ = await timed_upstream_call(
             get_initial_state(url=url, credential=credential)
         )
     except Exception as exc:
-        logger.warning(
-            "Article %s initial-state extraction failed: %s",
-            article_id,
-            exc,
-        )
+        logger.warning("Opus payload extraction failed for %s: %s", url, exc)
         return None
 
     if not isinstance(initial_state, dict):
         return None
-    return _build_markdown_from_initial_state(initial_state, preferred_title)
+
+    detail = initial_state.get("detail")
+    basic = detail.get("basic") if isinstance(detail, dict) else None
+    basic = basic if isinstance(basic, dict) else {}
+
+    fetched_title = basic.get("title") if isinstance(basic.get("title"), str) else None
+    title = (
+        preferred_title
+        if isinstance(preferred_title, str) and preferred_title.strip()
+        else fetched_title
+    )
+
+    rid_str = basic.get("rid_str") if isinstance(basic.get("rid_str"), str) else None
+    markdown = _build_markdown_from_initial_state(initial_state, preferred_title=title)
+
+    return {
+        "title": title,
+        "rid": coerce_int(rid_str) if rid_str else None,
+        "uid": coerce_int(basic.get("uid")),
+        "markdown_content": markdown,
+    }

--- a/bili_stalker_mcp/services/user_service.py
+++ b/bili_stalker_mcp/services/user_service.py
@@ -23,7 +23,7 @@ from ..models import (
 )
 from ..observability import record_cache_hit
 from ..parsers.dynamic_parser import format_timestamp
-from ..retry import RetryableBiliApiError, with_retry
+from ..retry import RetryableBiliApiError, is_retryable_error, with_retry
 from ..utils.converters import coerce_int, safe_aid_to_bvid
 from .article_renderer import (
     build_article_fallback_markdown,
@@ -388,22 +388,36 @@ async def _legacy_cv_markdown(
     cvid: int,
     cred: Credential | None,
 ) -> tuple[dict[str, Any] | None, str | None, str | None]:
-    """Try bilibili_api's legacy cv parser. Returns (info, markdown, error_reason)."""
+    """Try bilibili_api's legacy cv parser. Returns (info, markdown, error_reason).
+
+    Schema-mismatch failures (KeyError, or non-retryable ApiException from a
+    payload the SDK can't parse) return ``markdown=None`` so the caller falls
+    back to the opus page. Retryable upstream errors (rate limit, anti-bot
+    block, transient network) are re-raised so ``@with_retry`` on
+    ``fetch_article_content`` can handle them — otherwise transient outages
+    would be silently turned into a synthetic "content unavailable" success.
+    """
     client = article.Article(cvid=cvid, credential=cred)
     info = await timed_upstream_call(client.get_info())
     try:
         await timed_upstream_call(client.fetch_content())
         return info if isinstance(info, dict) else None, client.markdown(), None
-    except (KeyError, ApiException) as exc:
-        # Upstream schema for migrated articles drops readInfo or returns
-        # "未找到相关信息"; either way the opus-page fallback handles it.
+    except KeyError as exc:
         logger.warning(
-            "CV %s legacy parser failed (%s); falling back to opus page", cvid, exc
+            "CV %s legacy parser missing key %s; falling back to opus page", cvid, exc
         )
-        reason = (
-            f"unsupported payload key: {exc}" if isinstance(exc, KeyError) else str(exc)
+        return (
+            info if isinstance(info, dict) else None,
+            None,
+            f"unsupported payload key: {exc}",
         )
-        return info if isinstance(info, dict) else None, None, reason
+    except ApiException as exc:
+        if is_retryable_error(exc):
+            raise
+        logger.warning(
+            "CV %s legacy parser raised %s; falling back to opus page", cvid, exc
+        )
+        return info if isinstance(info, dict) else None, None, str(exc)
 
 
 @with_retry(max_retries=3, base_delay=2.0)

--- a/bili_stalker_mcp/services/user_service.py
+++ b/bili_stalker_mcp/services/user_service.py
@@ -27,7 +27,7 @@ from ..retry import RetryableBiliApiError, with_retry
 from ..utils.converters import coerce_int, safe_aid_to_bvid
 from .article_renderer import (
     build_article_fallback_markdown,
-    extract_markdown_from_opus_initial_state,
+    fetch_opus_payload,
 )
 from .subtitle_service import (
     DEFAULT_SUBTITLE_LANG,
@@ -228,7 +228,9 @@ async def fetch_user_videos(
     keyword: str = "",
 ) -> dict[str, Any]:
     u = user.User(uid=user_id, credential=cred)
-    video_list = await timed_upstream_call(u.get_videos(pn=page, ps=limit, keyword=keyword))
+    video_list = await timed_upstream_call(
+        u.get_videos(pn=page, ps=limit, keyword=keyword)
+    )
     raw_videos = (video_list.get("list") or {}).get("vlist") or []
 
     videos = []
@@ -280,9 +282,7 @@ async def _fetch_video_detail_cached(
         aid=coerce_int(video_data.get("aid")),
         title=video_data.get("title"),
         desc=video_data.get("desc"),
-        publish_time=format_timestamp(
-            coerce_int(video_data.get("pubdate"))
-        ),
+        publish_time=format_timestamp(coerce_int(video_data.get("pubdate"))),
         stat=VideoStatResponse(
             view=coerce_int(stat.get("view")),
             danmaku=coerce_int(stat.get("danmaku")),
@@ -347,7 +347,7 @@ async def fetch_user_articles(
     articles_data = await timed_upstream_call(u.get_articles(pn=page, ps=limit))
 
     article_items = []
-    for article_data in (articles_data.get("articles") or []):
+    for article_data in articles_data.get("articles") or []:
         if len(article_items) >= limit:
             break
 
@@ -356,7 +356,9 @@ async def fetch_user_articles(
                 id=coerce_int(article_data.get("id")),
                 title=article_data.get("title"),
                 summary=article_data.get("summary"),
-                publish_time_str=format_timestamp(coerce_int(article_data.get("publish_time"))),
+                publish_time_str=format_timestamp(
+                    coerce_int(article_data.get("publish_time"))
+                ),
                 stats=_filter_article_stats(article_data.get("stats")),
             )
         )
@@ -370,63 +372,91 @@ async def fetch_user_articles(
     return payload.model_dump()
 
 
+# Bilibili dynamic/opus snowflake ids are 64-bit; cv ids stay well below 2^53.
+# Anything above this threshold is treated as a new-style opus id.
+_OPUS_ID_THRESHOLD = 1 << 53
+
+
+def _opus_page_url(numeric_id: int) -> str:
+    """Resolve the opus-rendered page URL for either a cv id or an opus id."""
+    if numeric_id >= _OPUS_ID_THRESHOLD:
+        return f"https://www.bilibili.com/opus/{numeric_id}"
+    return f"https://www.bilibili.com/read/cv{numeric_id}/?jump_opus=1"
+
+
+async def _legacy_cv_markdown(
+    cvid: int,
+    cred: Credential | None,
+) -> tuple[dict[str, Any] | None, str | None, str | None]:
+    """Try bilibili_api's legacy cv parser. Returns (info, markdown, error_reason)."""
+    client = article.Article(cvid=cvid, credential=cred)
+    info = await timed_upstream_call(client.get_info())
+    try:
+        await timed_upstream_call(client.fetch_content())
+        return info if isinstance(info, dict) else None, client.markdown(), None
+    except (KeyError, ApiException) as exc:
+        # Upstream schema for migrated articles drops readInfo or returns
+        # "未找到相关信息"; either way the opus-page fallback handles it.
+        logger.warning(
+            "CV %s legacy parser failed (%s); falling back to opus page", cvid, exc
+        )
+        reason = (
+            f"unsupported payload key: {exc}" if isinstance(exc, KeyError) else str(exc)
+        )
+        return info if isinstance(info, dict) else None, None, reason
+
+
 @with_retry(max_retries=3, base_delay=2.0)
 async def fetch_article_content(
-    article_id: int,
+    article_id: int | str,
     cred: Credential | None,
 ) -> dict[str, Any]:
-    article_client = article.Article(cvid=article_id, credential=cred)
-
-    article_info = await timed_upstream_call(article_client.get_info())
-    article_title = article_info.get("title") if isinstance(article_info, dict) else None
-    markdown_content: str | None = None
-    parser_error_reason: str | None = None
-
+    """Fetch markdown for a bilibili article. Accepts a cv id or an opus snowflake id."""
     try:
-        # bilibili_api requires parsing content first before markdown conversion.
-        await timed_upstream_call(article_client.fetch_content())
-        markdown_content = article_client.markdown()
-    except KeyError as exc:
-        # New article schema in upstream may omit readInfo, breaking bilibili_api parser.
-        logger.warning(
-            "Article %s markdown payload is unsupported by upstream schema: %s",
-            article_id,
-            exc,
-        )
-        parser_error_reason = f"unsupported payload key: {exc}"
-    except ApiException as exc:
-        # Keep compatibility when upstream parser state cannot be built.
-        exc_str = str(exc)
-        if "fetch_content" in exc_str or "readInfo" in exc_str:
-            logger.warning(
-                "Article %s markdown parsing failed after fetch_content: %s",
-                article_id,
-                exc,
-            )
-            parser_error_reason = exc_str
-        else:
-            raise
+        numeric_id = int(article_id)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"article_id must be numeric, got: {article_id!r}") from exc
 
-    if markdown_content is None:
-        markdown_content = await extract_markdown_from_opus_initial_state(
-            article_id=article_id,
+    article_info: dict[str, Any] | None = None
+    title: str | None = None
+    markdown: str | None = None
+    error_reason: str | None = None
+
+    if numeric_id < _OPUS_ID_THRESHOLD:
+        article_info, markdown, error_reason = await _legacy_cv_markdown(
+            numeric_id, cred
+        )
+        if isinstance(article_info, dict) and isinstance(
+            article_info.get("title"), str
+        ):
+            title = article_info["title"]
+
+    if not (isinstance(markdown, str) and markdown.strip()):
+        payload = await fetch_opus_payload(
+            url=_opus_page_url(numeric_id),
             cred=cred,
-            preferred_title=article_title if isinstance(article_title, str) else None,
+            preferred_title=title,
+        )
+        if payload:
+            title = title or (
+                payload.get("title") if isinstance(payload.get("title"), str) else None
+            )
+            candidate = payload.get("markdown_content")
+            if isinstance(candidate, str) and candidate.strip():
+                markdown = candidate
+
+    if not (isinstance(markdown, str) and markdown.strip()):
+        markdown = build_article_fallback_markdown(
+            article_id=numeric_id,
+            article_info=article_info or ({"title": title} if title else None),
+            reason=error_reason or "upstream payload unavailable",
         )
 
-    if markdown_content is None:
-        markdown_content = build_article_fallback_markdown(
-            article_id=article_id,
-            article_info=article_info if isinstance(article_info, dict) else None,
-            reason=parser_error_reason or "upstream payload unavailable",
-        )
-
-    payload = ArticleContentResponse(
-        id=article_id,
-        title=article_title if isinstance(article_title, str) else None,
-        markdown_content=markdown_content if isinstance(markdown_content, str) else str(markdown_content),
-    )
-    return payload.model_dump()
+    return ArticleContentResponse(
+        id=str(numeric_id),
+        title=title,
+        markdown_content=markdown,
+    ).model_dump()
 
 
 @with_retry(max_retries=3, base_delay=2.0)

--- a/tests/test_article_content_flow.py
+++ b/tests/test_article_content_flow.py
@@ -35,7 +35,7 @@ async def test_fetch_article_content_calls_fetch_content_before_markdown(monkeyp
 
     assert calls == ["get_info", "fetch_content", "markdown"]
     assert result == {
-        "id": 42,
+        "id": "42",
         "title": "demo article",
         "markdown_content": "# hello\n\ncontent",
     }
@@ -124,7 +124,7 @@ async def test_fetch_article_content_parses_opus_initial_state_when_readinfo_mis
 
     result = await fetch_article_content(article_id=44386142, cred=None)
 
-    assert result["id"] == 44386142
+    assert result["id"] == "44386142"
     assert result["title"] == "legacy article"
     assert result["markdown_content"].startswith("# legacy article")
     assert "**第一段**" in result["markdown_content"]
@@ -166,7 +166,7 @@ async def test_fetch_article_content_keeps_fallback_when_initial_state_also_fail
 
     result = await fetch_article_content(article_id=44386142, cred=None)
 
-    assert result["id"] == 44386142
+    assert result["id"] == "44386142"
     assert result["title"] == "legacy article"
     assert "Full markdown content is unavailable" in result["markdown_content"]
     assert "readInfo" in result["markdown_content"]

--- a/tests/test_article_content_flow.py
+++ b/tests/test_article_content_flow.py
@@ -1,6 +1,10 @@
 import pytest
+from bilibili_api.exceptions import ResponseCodeException
 
-from bili_stalker_mcp.services.user_service import fetch_article_content
+from bili_stalker_mcp.services.user_service import (
+    _legacy_cv_markdown,
+    fetch_article_content,
+)
 
 
 @pytest.mark.asyncio
@@ -174,3 +178,34 @@ async def test_fetch_article_content_keeps_fallback_when_initial_state_also_fail
         "Source: https://www.bilibili.com/video/BV1xx411c7mD"
         in result["markdown_content"]
     )
+
+
+@pytest.mark.asyncio
+async def test_legacy_cv_markdown_reraises_retryable_api_errors(monkeypatch):
+    """Rate-limit / anti-bot errors must propagate so @with_retry can handle them.
+
+    Without re-raising, a transient -509 / -412 / 429 from the legacy SDK would
+    be silently converted into a fallback markdown response, masking the outage.
+    """
+
+    class FakeArticle:
+        def __init__(self, cvid, credential):
+            self.cvid = cvid
+            self.credential = credential
+
+        async def get_info(self):
+            return {"title": "rate-limited article"}
+
+        async def fetch_content(self):
+            # -509 is a retryable rate-limit code per DEFAULT_RETRYABLE_CODES.
+            raise ResponseCodeException(code=-509, msg="Request is rate-limited")
+
+        def markdown(self):
+            raise RuntimeError("should not be called")
+
+    monkeypatch.setattr(
+        "bili_stalker_mcp.services.user_service.article.Article", FakeArticle
+    )
+
+    with pytest.raises(ResponseCodeException):
+        await _legacy_cv_markdown(cvid=12345, cred=None)


### PR DESCRIPTION
## Summary

- `get_article_content` 现在同时接受 cv id（如 `21032785`）和 opus 动态 id（`bilibili.com/opus/{id}` URL 里的雪花 ID，如 `748254891671027745`）。
- `article_renderer` 中两个 `initial_state` 提取函数合并为统一的 `fetch_opus_payload(url, cred, preferred_title)`，调用方按 ID 类型选 URL。
- legacy cv 解析器的 `except` 由字符串匹配（仅 `"fetch_content"`/`"readInfo"`）改为 `except (KeyError, ApiException)`。**修复 bug**：上游对部分文章直接抛 `"未找到相关信息"` 时，原逻辑不会触发 opus 页面 fallback，导致 cv 21032785 这类已迁移到 opus 存储的老文章完全取不到内容。

## Breaking change

- `ArticleContentResponse.id`: `int` → `str`。原因：opus 雪花 ID 超过 JS 安全整数（2^53），经 JSON-RPC 传到客户端时会丢尾两位精度（实测 `748254891671027745` → `748254891671027700`）。统一成字符串后两种 ID 都能完整保留。

## Test plan

- [x] `pytest -q` 全部 52 个用例通过
- [x] 真实链接 `bilibili.com/opus/748254891671027745` 经 MCP 工具调用：返回 11107 字符 markdown，标题正确
- [x] 真实 cv id `21032785`（同篇文章的 cv 号，已经迁移到 opus 存储）：legacy 解析器失败 → 自动 fallback 到 opus 页面 → 返回 11100 字符 markdown
- [x] 同步更新 `tests/test_article_content_flow.py` 中 3 处 `id` 断言

## Out of scope

- 没有改 `uv.lock`，建议合并后 maintainer 自行 `uv sync`。