### PR TITLE
feat(comment): add video comment and reply tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ pip install bili-stalker-mcp
 | `get_user_articles` | Lightweight article list | `user_id_or_username`, `page`, `limit` |
 | `get_article_content` | Full article markdown content | `article_id` |
 | `get_user_followings` | Subscription list analysis | `user_id_or_username`, `page`, `limit` |
+| `get_video_comments` | Top-level comments with cursor pagination (each carries up to 3 preview sub-replies + pinned `top`) | `bvid`, `cursor`, `limit`, `sort` (`hot`/`time`) |
+| `get_video_comment_replies` | Full sub-replies of one top-level comment | `bvid`, `root_rpid`, `page`, `limit` |
 
 ### Dynamic Filtering (`dynamic_type`)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -69,6 +69,8 @@ pip install bili-stalker-mcp
 | `get_user_articles` | 轻量专栏列表 | `user_id_or_username`, `page`, `limit` |
 | `get_article_content` | 专栏 Markdown 全文 | `article_id` |
 | `get_user_followings` | 用户关注列表分析 | `user_id_or_username`, `page`, `limit` |
+| `get_video_comments` | 视频主评论（Cursor 分页，每条附最多 3 条子回复预览 + 置顶 `top`） | `bvid`, `cursor`, `limit`, `sort`（`hot`/`time`） |
+| `get_video_comment_replies` | 某条主评论的完整子回复 | `bvid`, `root_rpid`, `page`, `limit` |
 
 ### 动态类型过滤 (`dynamic_type`)
 

--- a/bili_stalker_mcp/core.py
+++ b/bili_stalker_mcp/core.py
@@ -15,6 +15,7 @@ from .services.dynamic_service import (
     is_dynamic_type_match,
     normalize_dynamic_type,
 )
+from .services.comment_service import fetch_comment_replies, fetch_video_comments
 from .services.user_service import (
     fetch_article_content,
     fetch_user_articles,
@@ -100,6 +101,8 @@ __all__ = [
     "fetch_user_articles",
     "fetch_article_content",
     "fetch_user_followings",
+    "fetch_video_comments",
+    "fetch_comment_replies",
     "_format_timestamp",
     "_get_shared_http_client",
     "_normalize_dynamic_type",

--- a/bili_stalker_mcp/models.py
+++ b/bili_stalker_mcp/models.py
@@ -188,7 +188,7 @@ class CommentsResponse(BaseModel):
     top: CommentItemResponse | None = None
     count: int = 0
     total: int = 0
-    page: int = 1
+    next_cursor: str | None = None
     has_more: bool = False
 
 

--- a/bili_stalker_mcp/models.py
+++ b/bili_stalker_mcp/models.py
@@ -186,6 +186,7 @@ CommentItemResponse.model_rebuild()
 class CommentsResponse(BaseModel):
     comments: list[CommentItemResponse] = Field(default_factory=list)
     top: CommentItemResponse | None = None
+    count: int = 0
     total: int = 0
     page: int = 1
     has_more: bool = False
@@ -193,6 +194,7 @@ class CommentsResponse(BaseModel):
 
 class CommentRepliesResponse(BaseModel):
     replies: list[CommentItemResponse] = Field(default_factory=list)
+    count: int = 0
     total: int = 0
     page: int = 1
     has_more: bool = False

--- a/bili_stalker_mcp/models.py
+++ b/bili_stalker_mcp/models.py
@@ -163,3 +163,36 @@ class FollowingItemResponse(BaseModel):
 class FollowingsResponse(BaseModel):
     followings: list[FollowingItemResponse] = Field(default_factory=list)
     total: int = 0
+
+
+class CommentMemberResponse(BaseModel):
+    mid: int | None = None
+    uname: str | None = None
+
+
+class CommentItemResponse(BaseModel):
+    rpid: int | None = None
+    content: str | None = None
+    member: CommentMemberResponse = Field(default_factory=CommentMemberResponse)
+    like: int | None = None
+    reply_count: int | None = None
+    publish_time: str | None = None
+    replies: list["CommentItemResponse"] = Field(default_factory=list)
+
+
+CommentItemResponse.model_rebuild()
+
+
+class CommentsResponse(BaseModel):
+    comments: list[CommentItemResponse] = Field(default_factory=list)
+    top: CommentItemResponse | None = None
+    total: int = 0
+    page: int = 1
+    has_more: bool = False
+
+
+class CommentRepliesResponse(BaseModel):
+    replies: list[CommentItemResponse] = Field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    has_more: bool = False

--- a/bili_stalker_mcp/server.py
+++ b/bili_stalker_mcp/server.py
@@ -584,10 +584,17 @@ def create_server() -> FastMCP:
                 description="Video BVID (e.g. BV1xx411c7mD), AV number (e.g. av170001), or a Bilibili video URL.",
             ),
         ],
-        page: Annotated[
-            int,
-            Field(ge=1, le=MAX_PAGE, description="Page number starting from 1."),
-        ] = 1,
+        cursor: Annotated[
+            str | None,
+            Field(
+                description=(
+                    "Pagination cursor. Omit (or null) for the first page. To get the "
+                    "next page, pass back the `next_cursor` returned by the previous call. "
+                    "Cursors are sequential only — you cannot jump to an arbitrary page, "
+                    "and a cursor is tied to its `sort`, so keep `sort` the same while paging."
+                ),
+            ),
+        ] = None,
         limit: Annotated[
             int,
             Field(ge=1, le=MAX_COMMENT_LIMIT, description=f"Comments per page, 1-{MAX_COMMENT_LIMIT}."),
@@ -597,12 +604,18 @@ def create_server() -> FastMCP:
             Field(description="Sort order: hot (by likes) or time (newest first)."),
         ] = "hot",
     ) -> Dict[str, Any]:
-        """Get top-level comments for a video. Each comment includes up to 3 preview sub-replies."""
+        """Get top-level comments for a video. Each comment includes up to 3 preview sub-replies.
+
+        Pagination is cursor-based: the first call returns `next_cursor`; pass it back as
+        `cursor` to fetch the following page, and stop when `has_more` is false (or
+        `next_cursor` is null). Use the same `sort` across a paging sequence. The pinned
+        `top` comment is only present on the first page.
+        """
 
         async def _runner() -> Dict[str, Any]:
             cred = _get_credential_from_context(ctx)
             resolved_bvid = await extract_bvid(bvid)
-            return await fetch_video_comments(resolved_bvid, page, limit, sort, cred)
+            return await fetch_video_comments(resolved_bvid, cursor, limit, sort, cred)
 
         try:
             return await _run_tool("get_video_comments", _runner)

--- a/bili_stalker_mcp/server.py
+++ b/bili_stalker_mcp/server.py
@@ -13,11 +13,13 @@ from .config import DynamicType
 from .utils import extract_bvid
 from .core import (
     fetch_article_content,
+    fetch_comment_replies,
     fetch_user_articles,
     fetch_user_dynamics,
     fetch_user_followings,
     fetch_user_info,
     fetch_user_videos,
+    fetch_video_comments,
     fetch_video_detail,
     get_credential,
     get_user_id_by_username,
@@ -562,5 +564,96 @@ def create_server() -> FastMCP:
         except Exception as exc:
             logger.exception("get_user_followings failed")
             raise ToolError(f"Failed to fetch user followings: {exc}")
+
+    MAX_COMMENT_LIMIT = 20
+    CommentSortLiteral = Literal["hot", "time"]
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        }
+    )
+    async def get_video_comments(
+        ctx: Context,
+        bvid: Annotated[
+            str,
+            Field(
+                min_length=3,
+                description="Video BVID (e.g. BV1xx411c7mD), AV number (e.g. av170001), or a Bilibili video URL.",
+            ),
+        ],
+        page: Annotated[
+            int,
+            Field(ge=1, le=MAX_PAGE, description="Page number starting from 1."),
+        ] = 1,
+        limit: Annotated[
+            int,
+            Field(ge=1, le=MAX_COMMENT_LIMIT, description=f"Comments per page, 1-{MAX_COMMENT_LIMIT}."),
+        ] = 20,
+        sort: Annotated[
+            CommentSortLiteral,
+            Field(description="Sort order: hot (by likes) or time (newest first)."),
+        ] = "hot",
+    ) -> Dict[str, Any]:
+        """Get top-level comments for a video. Each comment includes up to 3 preview sub-replies."""
+
+        async def _runner() -> Dict[str, Any]:
+            cred = _get_credential_from_context(ctx)
+            resolved_bvid = await extract_bvid(bvid)
+            return await fetch_video_comments(resolved_bvid, page, limit, sort, cred)
+
+        try:
+            return await _run_tool("get_video_comments", _runner)
+        except ToolError:
+            raise
+        except Exception as exc:
+            logger.exception("get_video_comments failed")
+            raise ToolError(f"Failed to fetch video comments: {exc}")
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+        }
+    )
+    async def get_video_comment_replies(
+        ctx: Context,
+        bvid: Annotated[
+            str,
+            Field(
+                min_length=3,
+                description="Video BVID (e.g. BV1xx411c7mD), AV number (e.g. av170001), or a Bilibili video URL.",
+            ),
+        ],
+        root_rpid: Annotated[
+            int,
+            Field(ge=1, description="The rpid of the top-level comment whose sub-replies to fetch."),
+        ],
+        page: Annotated[
+            int,
+            Field(ge=1, le=MAX_PAGE, description="Page number starting from 1."),
+        ] = 1,
+        limit: Annotated[
+            int,
+            Field(ge=1, le=MAX_COMMENT_LIMIT, description=f"Replies per page, 1-{MAX_COMMENT_LIMIT}."),
+        ] = 20,
+    ) -> Dict[str, Any]:
+        """Get sub-replies for a top-level video comment identified by its rpid."""
+
+        async def _runner() -> Dict[str, Any]:
+            cred = _get_credential_from_context(ctx)
+            resolved_bvid = await extract_bvid(bvid)
+            return await fetch_comment_replies(resolved_bvid, root_rpid, page, limit, cred)
+
+        try:
+            return await _run_tool("get_video_comment_replies", _runner)
+        except ToolError:
+            raise
+        except Exception as exc:
+            logger.exception("get_video_comment_replies failed")
+            raise ToolError(f"Failed to fetch comment replies: {exc}")
 
     return mcp

--- a/bili_stalker_mcp/services/comment_service.py
+++ b/bili_stalker_mcp/services/comment_service.py
@@ -105,6 +105,7 @@ async def fetch_video_comments(
     return CommentsResponse(
         comments=comments,
         top=top_comment,
+        count=len(comments),
         total=total,
         page=page,
         has_more=has_more,
@@ -144,6 +145,7 @@ async def fetch_comment_replies(
 
     return CommentRepliesResponse(
         replies=replies,
+        count=len(replies),
         total=total,
         page=page,
         has_more=(page * limit) < total,

--- a/bili_stalker_mcp/services/comment_service.py
+++ b/bili_stalker_mcp/services/comment_service.py
@@ -67,12 +67,16 @@ def _check_comment_api_error(data: dict[str, Any], url: str) -> None:
 @with_retry(max_retries=3, base_delay=2.0)
 async def fetch_video_comments(
     bvid: str,
-    page: int,
+    cursor: str | None,
     limit: int,
     sort: str,
     cred: Credential | None,
 ) -> dict[str, Any]:
-    if page > 1:
+    # reply/main is cursor-paginated: the first page omits `next`, and each
+    # subsequent page must echo back the previous response's cursor. For the
+    # time sort the cursor is a content-derived value (not a page index), so a
+    # stateless page number cannot work — callers carry `cursor` forward.
+    if cursor:
         await asyncio.sleep(REQUEST_DELAY)
 
     aid = await _get_aid_cached(bvid, cred)
@@ -84,30 +88,34 @@ async def fetch_video_comments(
         "oid": aid,
         "mode": mode,
         "ps": limit,
-        "pn": page,
     }
+    if cursor:
+        params["next"] = cursor
+
     data = await get_json(url, params=params, cred=cred)
     _check_comment_api_error(data, url)
 
     payload_data = data.get("data") or {}
     raw_replies = payload_data.get("replies") or []
-    cursor = payload_data.get("cursor") or {}
+    cursor_info = payload_data.get("cursor") or {}
 
+    # `top` is only returned on the first page; preserve it when present.
     top_raw = (payload_data.get("top") or {}).get("upper") or (payload_data.get("top") or {}).get("admin")
     top_comment = _parse_comment(top_raw) if isinstance(top_raw, dict) else None
 
     comments = [_parse_comment(r) for r in raw_replies if isinstance(r, dict)]
-    total = coerce_int(cursor.get("all_count")) or len(comments)
+    total = coerce_int(cursor_info.get("all_count")) or len(comments)
 
-    is_end = cursor.get("is_end")
+    is_end = cursor_info.get("is_end")
     has_more = (not is_end) if is_end is not None else (len(comments) >= limit)
+    next_cursor = str(cursor_info.get("next")) if has_more and cursor_info.get("next") is not None else None
 
     return CommentsResponse(
         comments=comments,
         top=top_comment,
         count=len(comments),
         total=total,
-        page=page,
+        next_cursor=next_cursor,
         has_more=has_more,
     ).model_dump()
 

--- a/bili_stalker_mcp/services/comment_service.py
+++ b/bili_stalker_mcp/services/comment_service.py
@@ -1,0 +1,150 @@
+import asyncio
+import logging
+from typing import Any
+
+from async_lru import alru_cache
+from bilibili_api import Credential
+
+from ..config import REQUEST_DELAY
+from ..infra.http_client import get_json
+from ..models import (
+    CommentItemResponse,
+    CommentMemberResponse,
+    CommentRepliesResponse,
+    CommentsResponse,
+)
+from ..parsers.dynamic_parser import format_timestamp
+from ..retry import RetryableBiliApiError, with_retry
+from ..utils.converters import coerce_int
+
+logger = logging.getLogger(__name__)
+
+_COMMENT_TYPE_VIDEO = 1
+_COMMENT_SORT_HOT = 3
+_COMMENT_SORT_TIME = 2
+
+
+@alru_cache(maxsize=256, ttl=300)
+async def _get_aid_cached(bvid: str, cred: Credential | None) -> int:
+    url = "https://api.bilibili.com/x/web-interface/view"
+    data = await get_json(url, params={"bvid": bvid}, cred=cred)
+    if data.get("code") != 0:
+        raise ValueError(f"Failed to resolve bvid {bvid}: {data.get('message')}")
+    aid = coerce_int((data.get("data") or {}).get("aid"))
+    if aid is None:
+        raise ValueError(f"No aid returned for bvid {bvid}")
+    return aid
+
+
+def _parse_comment(raw: dict[str, Any]) -> CommentItemResponse:
+    content_dict = raw.get("content") or {}
+    member_dict = raw.get("member") or {}
+    raw_replies = raw.get("replies") or []
+    return CommentItemResponse(
+        rpid=coerce_int(raw.get("rpid")),
+        content=content_dict.get("message"),
+        member=CommentMemberResponse(
+            mid=coerce_int(member_dict.get("mid")),
+            uname=member_dict.get("uname"),
+        ),
+        like=coerce_int(raw.get("like")),
+        reply_count=coerce_int(raw.get("rcount")),
+        publish_time=format_timestamp(coerce_int(raw.get("ctime"))),
+        replies=[_parse_comment(r) for r in raw_replies if isinstance(r, dict)],
+    )
+
+
+def _check_comment_api_error(data: dict[str, Any], url: str) -> None:
+    code = data.get("code")
+    if code == -412:
+        raise RetryableBiliApiError(code=-412, message=f"Request blocked by Bilibili ({url})")
+    if code == -509:
+        raise RetryableBiliApiError(code=-509, message=f"Request rate-limited by Bilibili ({url})")
+    if code != 0:
+        raise ValueError(f"Comment API error (code {code}): {data.get('message')} ({url})")
+
+
+@with_retry(max_retries=3, base_delay=2.0)
+async def fetch_video_comments(
+    bvid: str,
+    page: int,
+    limit: int,
+    sort: str,
+    cred: Credential | None,
+) -> dict[str, Any]:
+    if page > 1:
+        await asyncio.sleep(REQUEST_DELAY)
+
+    aid = await _get_aid_cached(bvid, cred)
+    mode = _COMMENT_SORT_HOT if sort == "hot" else _COMMENT_SORT_TIME
+
+    url = "https://api.bilibili.com/x/v2/reply/main"
+    params: dict[str, Any] = {
+        "type": _COMMENT_TYPE_VIDEO,
+        "oid": aid,
+        "mode": mode,
+        "ps": limit,
+        "pn": page,
+    }
+    data = await get_json(url, params=params, cred=cred)
+    _check_comment_api_error(data, url)
+
+    payload_data = data.get("data") or {}
+    raw_replies = payload_data.get("replies") or []
+    cursor = payload_data.get("cursor") or {}
+
+    top_raw = (payload_data.get("top") or {}).get("upper") or (payload_data.get("top") or {}).get("admin")
+    top_comment = _parse_comment(top_raw) if isinstance(top_raw, dict) else None
+
+    comments = [_parse_comment(r) for r in raw_replies if isinstance(r, dict)]
+    total = coerce_int(cursor.get("all_count")) or len(comments)
+
+    is_end = cursor.get("is_end")
+    has_more = (not is_end) if is_end is not None else (len(comments) >= limit)
+
+    return CommentsResponse(
+        comments=comments,
+        top=top_comment,
+        total=total,
+        page=page,
+        has_more=has_more,
+    ).model_dump()
+
+
+@with_retry(max_retries=3, base_delay=2.0)
+async def fetch_comment_replies(
+    bvid: str,
+    root_rpid: int,
+    page: int,
+    limit: int,
+    cred: Credential | None,
+) -> dict[str, Any]:
+    if page > 1:
+        await asyncio.sleep(REQUEST_DELAY)
+
+    aid = await _get_aid_cached(bvid, cred)
+
+    url = "https://api.bilibili.com/x/v2/reply/reply"
+    params: dict[str, Any] = {
+        "type": _COMMENT_TYPE_VIDEO,
+        "oid": aid,
+        "root": root_rpid,
+        "ps": limit,
+        "pn": page,
+    }
+    data = await get_json(url, params=params, cred=cred)
+    _check_comment_api_error(data, url)
+
+    payload_data = data.get("data") or {}
+    raw_replies = payload_data.get("replies") or []
+    page_info = payload_data.get("page") or {}
+
+    replies = [_parse_comment(r) for r in raw_replies if isinstance(r, dict)]
+    total = coerce_int(page_info.get("count")) or len(replies)
+
+    return CommentRepliesResponse(
+        replies=replies,
+        total=total,
+        page=page,
+        has_more=(page * limit) < total,
+    ).model_dump()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -103,7 +103,7 @@ wheels = [
 
 [[package]]
 name = "bili-stalker-mcp"
-version = "3.0.0"
+version = "3.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "async-lru" },
@@ -274,10 +274,16 @@ sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
     { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
     { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
     { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
     { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
     { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
     { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 


### PR DESCRIPTION
## 概述

新增两个只读 MCP tool,基于 B 站评论 API(`/x/v2/reply/main` 与 `/x/v2/reply/reply`),仅需 SESSDATA。

## 新增 tool

- **`get_video_comments(bvid, cursor=None, limit=20, sort="hot")`** — 获取主评论列表
  - `sort`: `hot`(按热度,mode=3)| `time`(按时间,mode=2)
  - `bvid` 接受 BV 号 / av 号 / 完整 URL(复用 `extract_bvid`)
  - **游标翻页**:首次调用不传 `cursor`;响应返回 `next_cursor`,把它回传即可取下一页,直到 `has_more=false`。游标与 `sort` 绑定,翻页过程中保持 `sort` 不变,且只能顺序往后翻、不能跳页。
  - 返回:`comments`(每条带最多 3 条子回复预览)、置顶评论 `top`(仅首页)、`count`(本页条数)、`total`(全站总评论数)、`next_cursor`、`has_more`
- **`get_video_comment_replies(bvid, root_rpid, page=1, limit=20)`** — 获取某条主评论的完整子回复
  - `reply/reply` 是真正的 `pn` 翻页,沿用 `page` 参数

## 实现细节

- 新增 `services/comment_service.py`:
  - `bvid → aid` 解析走 `/x/web-interface/view`,用 `alru_cache`(maxsize=256, ttl=300)缓存
  - HTTP 统一走 `infra/http_client.get_json`
  - 评论 API 的 `-412` / `-509` 映射为 `RetryableBiliApiError`,由 `with_retry` 自动重试;翻页时 `REQUEST_DELAY` sleep 规避频控
  - **主评论翻页用 `reply/main` 的 `next` 游标**(详见下方 Codex review 修复说明)
- `models.py`:新增 `CommentItemResponse` / `CommentMemberResponse` / `CommentsResponse` / `CommentRepliesResponse`(`CommentItemResponse` 递归引用,已 `model_rebuild()`)
- `core.py` re-export,`server.py` 注册 tool,annotations 固定 `readOnlyHint=True, destructiveHint=False, idempotentHint=True`
- 游标翻页约定与现有 `get_user_dynamics` 保持一致(同样是 `cursor` / `next_cursor`)

## Codex review 修复(P2:翻页)

Codex 指出 `reply/main` 是游标翻页、`pn` 会被忽略 —— **属实**。实测确认:`pn=1` 与 `pn=2` 返回完全相同的内容。进一步验证了底层机制:

- **热门(mode=3)**:`cursor.next` 是顺序页码(1→2→3),`next=页码` 碰巧能用。
- **时间(mode=2)**:`cursor.next` 是内容相关的非顺序游标(78→67→…),无状态页码**根本无法**推导。
- 老接口 `/x/v2/reply` 已基本废弃(`pn>1` 返回空、无子回复预览),不可用。

**修复**:把 `page` 参数改为不透明的 `cursor`(首页省略,后续回传上一页的 `next_cursor`),统一走 `reply/main` 的 `next` 游标。已端到端验证热门 / 时间两种排序都能返回**互不重复、正确前进**的页。tool description 已向 LLM 写明游标契约。

## 测试

- `get_video_comments`:对真实视频实测热门 + 时间两种排序的连续翻页,page1/page2 内容不重叠,`next_cursor` 正确递进,`top` 仅首页出现。

> 注:只读实现,只有 SESSDATA、无 bili_jct,不涉及发评论。
